### PR TITLE
Skip problematic property in bonds subgraph

### DIFF
--- a/src/graphql/bondMarket.graphql
+++ b/src/graphql/bondMarket.graphql
@@ -5,7 +5,6 @@ query MarketCreatedEvents($sinceBlock: BigInt!) {
     bondType
     date
     id
-    marketId
     timestamp
     market {
       bondContract
@@ -42,7 +41,6 @@ query MarketClosedEvents($sinceBlock: BigInt!) {
     bondType
     date
     id
-    marketId
     timestamp
     market {
       bondContract

--- a/src/graphql/bondMarket.patch
+++ b/src/graphql/bondMarket.patch
@@ -1,28 +1,36 @@
 diff --git forkSrcPrefix/src/graphql/bondMarket.ts forkDstPrefix/src/graphql/bondMarket.ts
-index 8ad8e48a828f9d2ba7b9b2ed03771dd19145d283..9b29728c8cdf8bd4b761daf7cc1d98405f90f966 100644
+index 9b29728c8cdf8bd4b761daf7cc1d98405f90f966..b60f8a9ea1d6a11f726841de4fc2d1888dae130f 100644
 --- forkSrcPrefix/src/graphql/bondMarket.ts
 +++ forkDstPrefix/src/graphql/bondMarket.ts
-@@ -377,9 +377,9 @@ export enum MarketClosedEvent_OrderBy {
-   MarketCreatedTimestamp = "market__createdTimestamp",
-   MarketDurationActualMilliseconds = "market__durationActualMilliseconds",
-   MarketDurationMilliseconds = "market__durationMilliseconds",
--  MarketId = "market__id",
-+  Market_Id = "market__id",
-   MarketInitialPriceInQuoteToken = "market__initialPriceInQuoteToken",
--  MarketMarketId = "market__marketId",
-+  Market_MarketId = "market__marketId",
-   MarketMaxPayoutInPayoutToken = "market__maxPayoutInPayoutToken",
-   MarketMinPriceInQuoteToken = "market__minPriceInQuoteToken",
-   MarketOwner = "market__owner",
-@@ -517,9 +517,9 @@ export enum MarketCreatedEvent_OrderBy {
-   MarketCreatedTimestamp = "market__createdTimestamp",
-   MarketDurationActualMilliseconds = "market__durationActualMilliseconds",
-   MarketDurationMilliseconds = "market__durationMilliseconds",
--  MarketId = "market__id",
-+  Market_Id = "market__id",
-   MarketInitialPriceInQuoteToken = "market__initialPriceInQuoteToken",
--  MarketMarketId = "market__marketId",
-+  Market_MarketId = "market__marketId",
-   MarketMaxPayoutInPayoutToken = "market__maxPayoutInPayoutToken",
-   MarketMinPriceInQuoteToken = "market__minPriceInQuoteToken",
-   MarketOwner = "market__owner",
+@@ -260,7 +260,6 @@ export type MarketClosedEvent = {
+   date: Scalars["String"];
+   id: Scalars["ID"];
+   market: Market;
+-  marketId: Scalars["BigInt"];
+   timestamp: Scalars["BigInt"];
+ };
+ 
+@@ -365,7 +364,6 @@ export enum MarketClosedEvent_OrderBy {
+   Date = "date",
+   Id = "id",
+   Market = "market",
+-  MarketId = "marketId",
+   MarketBondContract = "market__bondContract",
+   MarketBondType = "market__bondType",
+   MarketCapacityInPayoutToken = "market__capacityInPayoutToken",
+@@ -400,7 +398,6 @@ export type MarketCreatedEvent = {
+   date: Scalars["String"];
+   id: Scalars["ID"];
+   market: Market;
+-  marketId: Scalars["BigInt"];
+   timestamp: Scalars["BigInt"];
+ };
+ 
+@@ -505,7 +502,6 @@ export enum MarketCreatedEvent_OrderBy {
+   Date = "date",
+   Id = "id",
+   Market = "market",
+-  MarketId = "marketId",
+   MarketBondContract = "market__bondContract",
+   MarketBondType = "market__bondType",
+   MarketCapacityInPayoutToken = "market__capacityInPayoutToken",

--- a/src/graphql/bondMarket.ts
+++ b/src/graphql/bondMarket.ts
@@ -260,7 +260,6 @@ export type MarketClosedEvent = {
   date: Scalars["String"];
   id: Scalars["ID"];
   market: Market;
-  marketId: Scalars["BigInt"];
   timestamp: Scalars["BigInt"];
 };
 
@@ -365,7 +364,6 @@ export enum MarketClosedEvent_OrderBy {
   Date = "date",
   Id = "id",
   Market = "market",
-  MarketId = "marketId",
   MarketBondContract = "market__bondContract",
   MarketBondType = "market__bondType",
   MarketCapacityInPayoutToken = "market__capacityInPayoutToken",
@@ -377,9 +375,9 @@ export enum MarketClosedEvent_OrderBy {
   MarketCreatedTimestamp = "market__createdTimestamp",
   MarketDurationActualMilliseconds = "market__durationActualMilliseconds",
   MarketDurationMilliseconds = "market__durationMilliseconds",
-  Market_Id = "market__id",
+  MarketId = "market__id",
   MarketInitialPriceInQuoteToken = "market__initialPriceInQuoteToken",
-  Market_MarketId = "market__marketId",
+  MarketMarketId = "market__marketId",
   MarketMaxPayoutInPayoutToken = "market__maxPayoutInPayoutToken",
   MarketMinPriceInQuoteToken = "market__minPriceInQuoteToken",
   MarketOwner = "market__owner",
@@ -400,7 +398,6 @@ export type MarketCreatedEvent = {
   date: Scalars["String"];
   id: Scalars["ID"];
   market: Market;
-  marketId: Scalars["BigInt"];
   timestamp: Scalars["BigInt"];
 };
 
@@ -505,7 +502,6 @@ export enum MarketCreatedEvent_OrderBy {
   Date = "date",
   Id = "id",
   Market = "market",
-  MarketId = "marketId",
   MarketBondContract = "market__bondContract",
   MarketBondType = "market__bondType",
   MarketCapacityInPayoutToken = "market__capacityInPayoutToken",
@@ -517,9 +513,9 @@ export enum MarketCreatedEvent_OrderBy {
   MarketCreatedTimestamp = "market__createdTimestamp",
   MarketDurationActualMilliseconds = "market__durationActualMilliseconds",
   MarketDurationMilliseconds = "market__durationMilliseconds",
-  Market_Id = "market__id",
+  MarketId = "market__id",
   MarketInitialPriceInQuoteToken = "market__initialPriceInQuoteToken",
-  Market_MarketId = "market__marketId",
+  MarketMarketId = "market__marketId",
   MarketMaxPayoutInPayoutToken = "market__maxPayoutInPayoutToken",
   MarketMinPriceInQuoteToken = "market__minPriceInQuoteToken",
   MarketOwner = "market__owner",
@@ -994,7 +990,6 @@ export type MarketCreatedEventsQuery = {
     bondType: BondType;
     date: string;
     id: string;
-    marketId: string;
     timestamp: string;
     market: {
       __typename?: "Market";
@@ -1038,7 +1033,6 @@ export type MarketClosedEventsQuery = {
     bondType: BondType;
     date: string;
     id: string;
-    marketId: string;
     timestamp: string;
     market: {
       __typename?: "Market";
@@ -1124,7 +1118,6 @@ export const MarketCreatedEventsDocument = {
                 { kind: "Field", name: { kind: "Name", value: "bondType" } },
                 { kind: "Field", name: { kind: "Name", value: "date" } },
                 { kind: "Field", name: { kind: "Name", value: "id" } },
-                { kind: "Field", name: { kind: "Name", value: "marketId" } },
                 { kind: "Field", name: { kind: "Name", value: "timestamp" } },
                 {
                   kind: "Field",
@@ -1221,7 +1214,6 @@ export const MarketClosedEventsDocument = {
                 { kind: "Field", name: { kind: "Name", value: "bondType" } },
                 { kind: "Field", name: { kind: "Name", value: "date" } },
                 { kind: "Field", name: { kind: "Name", value: "id" } },
-                { kind: "Field", name: { kind: "Name", value: "marketId" } },
                 { kind: "Field", name: { kind: "Name", value: "timestamp" } },
                 {
                   kind: "Field",

--- a/src/snapshotCheck/checkBondMarkets.ts
+++ b/src/snapshotCheck/checkBondMarkets.ts
@@ -59,7 +59,7 @@ const filterCreatedEvents = (events: MarketCreatedEvent[], block: number, market
     return filteredByBlock;
   }
 
-  return filteredByBlock.filter(createdEvent => castInt(createdEvent.marketId) == marketId);
+  return filteredByBlock.filter(createdEvent => castInt(createdEvent.market.marketId) == marketId);
 };
 
 const filterClosedEvents = (events: MarketClosedEvent[], block: number, marketId?: number): MarketClosedEvent[] => {
@@ -69,7 +69,7 @@ const filterClosedEvents = (events: MarketClosedEvent[], block: number, marketId
     return filteredByBlock;
   }
 
-  return filteredByBlock.filter(createdEvent => castInt(createdEvent.marketId) == marketId);
+  return filteredByBlock.filter(createdEvent => castInt(createdEvent.market.marketId) == marketId);
 };
 
 const pushError = (error: string, errors: string[]): void => {
@@ -373,7 +373,7 @@ const checkCushionDown = (
   // If none of the above conditions are true, then the bond market was closed for an unknown reason, and we want to alert about that
   if (!durationExceeded && !priceInRange && !priceOutsideWall && !capacityExhausted && !hasWallUpRegenerationEvent) {
     pushError(
-      `Expected market (${closedMarket.marketId}) to be closed due to one of the following (but it was not): duration exceeded, price outside wall, price in range, capacity exhausted, wall regeneration`,
+      `Expected market (${closedMarket.market.marketId}) to be closed due to one of the following (but it was not): duration exceeded, price outside wall, price in range, capacity exhausted, wall regeneration`,
       errors,
     );
   } else {
@@ -405,7 +405,7 @@ const checkMarketCreated = (
 
   const matchingCushionUpEvents = cushionUpEvents.filter(
     priceEvent =>
-      castInt(event.marketId) ==
+      castInt(event.market.marketId) ==
       castIntNullable(priceEvent.isHigh ? priceEvent.snapshot.highMarketId : priceEvent.snapshot.lowMarketId),
   );
 
@@ -742,7 +742,7 @@ export const checkBondMarkets = async (
       sendAlert(webhookUrl, getRoleMentions(mentionRoles), `🚨 CreatedMarket Discrepancies`, toUnorderedList(errors), [
         {
           name: "Market ID",
-          value: `${marketEvent.marketId}`,
+          value: `${marketEvent.market.marketId}`,
         },
         { name: "Block", value: `${marketEvent.block}` },
         ...getShutdownEmbedField(contractUrl),
@@ -757,7 +757,7 @@ export const checkBondMarkets = async (
       sendAlert(webhookUrl, getRoleMentions(mentionRoles), `🚨 ClosedMarket Discrepancies`, toUnorderedList(errors), [
         {
           name: "Market ID",
-          value: `${marketEvent.marketId}`,
+          value: `${marketEvent.market.marketId}`,
         },
         { name: "Block", value: `${marketEvent.block}` },
         ...getShutdownEmbedField(contractUrl),


### PR DESCRIPTION
The `marketId` property causes problems with typing, is redundant, and will likely be removed. This PR strips it from the generated code so that upon removal, there will be no issues.