### PR TITLE
docs: add common task guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,46 @@ State is stored in a single Firestore document per environment:
 
 ## Development Workflow
 
+### Common Commands
+
+Install dependencies with pnpm:
+
+```bash
+pnpm install
+```
+
+The repo uses `pnpm-workspace.yaml` for shared pnpm policy:
+
+- `nodeLinker: hoisted` is required for Pulumi's Node.js function serialization and avoids `.pnpm/...` closure-loading or export-path errors.
+- `minimumReleaseAge`, `strictDepBuilds`, `blockExoticSubdeps`, `preferFrozenLockfile`, and `overrides` are pnpm settings. They should stay in `pnpm-workspace.yaml`, not `.npmrc`.
+- Avoid `npx` in lifecycle scripts. pnpm exposes its settings to lifecycle scripts through `npm_config_*` environment variables, and npm/npx reports pnpm-only settings as unknown env config warnings.
+
+Common verification commands:
+
+```bash
+pnpm run codegen
+pnpm run lint
+pnpm run build
+```
+
+Run `pnpm run codegen` only when GraphQL documents or schema inputs change. Run `pnpm run lint` and `pnpm run build` after code changes.
+
+Local monitor scripts load `.env` and execute the corresponding handler:
+
+```bash
+pnpm run execute:events
+pnpm run execute:heartbeats
+pnpm run execute:snapshots
+pnpm run execute:targetPrice
+pnpm run execute:yrfmarkets
+pnpm run execute:emissionmanagermarkets
+pnpm run execute:failedperiodictasks
+pnpm run execute:bondmarketcreationfailed
+pnpm run execute:auctionparametersupdated
+pnpm run execute:auctionresult
+pnpm run execute:claimedyield
+```
+
 ### Adding New Functions/Endpoints
 
 1. **Create Handler Function**:
@@ -278,16 +318,42 @@ This ensures code quality and catches any type errors or linting issues before c
 
 ## Deployment
 
-### Environment Stacks
+### Pulumi Stacks
 
-- **dev**: `pnpm run deploy:dev` or `pulumi up --stack dev`
-- **prod**: `pnpm run deploy:prod` or `pulumi up --stack prod`
+Pulumi manages Google Cloud Functions, Scheduler jobs, Firestore state, Monitoring alert policies, dashboards, and notification channels. Deploy through the package scripts:
+
+- **dev**: `pnpm run deploy:dev`
+- **prod**: `pnpm run deploy:prod`
+
+Equivalent direct Pulumi commands:
+
+```bash
+pulumi up --stack dev
+pulumi up --stack prod
+```
+
+Use `pulumi preview --stack <stack>` before applying changes when you need to inspect infrastructure diffs without deploying.
 
 ### Prerequisites
 
 1. Set GCP project and region in Pulumi configuration
 2. Configure required secrets in Pulumi
 3. Ensure GraphQL API key is valid
+4. Ensure the active GCP credentials can update Cloud Functions, Scheduler, Firestore, Monitoring, and notification channels
+
+Required stack config includes:
+
+- `gcp:project`
+- `gcp:region`
+- `GRAPHQL_API_KEY`
+- `discordWebhookAlert`
+- `discordWebhookAlertCommunity`
+- `discordWebhookEmergency`
+- `notificationEmail`
+- `notificationEmailDiscord`
+- `discordRoleIdCore`
+- `contractUrl`
+- `CONVERTIBLE_DEPOSITS_SUBGRAPH_URL`
 
 ### Monitoring
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,68 @@ To be implemented:
 
 Secrets are stored in Pulumi on a per-stack basis.
 
+## Common Tasks
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+This repository uses pnpm configuration from `pnpm-workspace.yaml`, including the hoisted linker layout required by Pulumi's Node.js closure serialization. Do not move these settings back to `.npmrc`; npm and `npx` do not understand pnpm-only keys such as `minimumReleaseAge`, `strictDepBuilds`, `blockExoticSubdeps`, or `nodeLinker`.
+
+Regenerate GraphQL types after editing `src/graphql/*.graphql` files:
+
+```bash
+pnpm run codegen
+```
+
+Run formatting and lint fixes:
+
+```bash
+pnpm run lint
+```
+
+Check TypeScript compilation:
+
+```bash
+pnpm run build
+```
+
+Run a monitor locally against values from `.env`:
+
+```bash
+pnpm run execute:events
+pnpm run execute:heartbeats
+pnpm run execute:snapshots
+pnpm run execute:targetPrice
+pnpm run execute:yrfmarkets
+```
+
 ## Deployment
 
-`pnpm run deploy:dev`
+Deployments are managed by Pulumi. The package scripts wrap the corresponding stack commands:
 
-`pnpm run deploy:prod`
+```bash
+pnpm run deploy:dev
+pnpm run deploy:prod
+```
 
-Pulumi may require pnpm's hoisted linker layout to avoid `.pnpm/...` closure-loading or export-path errors; this repo sets `node-linker=hoisted` in `.npmrc` for that reason.
+Equivalent Pulumi commands:
+
+```bash
+pulumi up --stack dev
+pulumi up --stack prod
+```
+
+Before deploying, confirm the selected stack with `pulumi stack ls` or `pulumi stack select <stack>`, and verify that the required stack config is present:
+
+```bash
+pulumi config --stack dev
+pulumi config --stack prod
+```
+
+Required stack config includes `gcp:project`, `gcp:region`, `GRAPHQL_API_KEY`, Discord webhook URLs, notification emails, `discordRoleIdCore`, `contractUrl`, and `CONVERTIBLE_DEPOSITS_SUBGRAPH_URL`.
 
 ## How To Update Subgraph Versions
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "lint": "biome check --write .",
     "lint:check": "biome check .",
     "deploy:dev": "pulumi up --stack dev",
-    "deploy:prod": "pulumi up --stack prod",
-    "preinstall": "npx only-allow@1.2.2 pnpm"
+    "deploy:prod": "pulumi up --stack prod"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",


### PR DESCRIPTION
## Summary

- Document common development tasks for install, codegen, lint, build, and local handler execution.
- Expand Pulumi deployment notes for dev/prod stacks and required configuration.
- Remove the preinstall hook that invoked npx only-allow, which caused npm unknown-config warnings during pnpm install because npm/npx does not recognize pnpm-only lifecycle config.

## Validation

- pnpm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development and deployment guides with detailed command references and stack configuration requirements.
  * Added "Common Tasks" section documenting day-to-day operations including installation, code generation, linting, and local monitoring.

* **Chores**
  * Removed preinstall script configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OlympusDAO/rbs-discord-alerts/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->