### PR TITLE
fix(deps): update pnpm security overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,16 +6,14 @@ settings:
 
 overrides:
   '@ardatan/relay-compiler@12.0.0>immutable': ^4.3.9
-  brace-expansion@<1.1.16: ^1.1.16
-  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
-  brace-expansion@>=5.0.0 <5.0.7: ^5.0.7
+  brace-expansion@<=5.0.7: ^5.0.8
   js-yaml@>=4.0.0 <4.3.0: ^4.3.0
   lodash@>=4.0.0 <=4.17.23: ^4.18.0
   minimatch@>=4.0.0 <4.2.5: ^4.2.5
   protobufjs@>=7.5.0 <=7.6.4: ^7.6.5
   shell-quote@<=1.8.4: ^1.10.0
   sigstore@<=4.1.0: ^4.1.1
-  tar@<=7.5.18: ^7.5.19
+  tar@<=7.5.20: ^7.5.21
   tmp@<0.2.6: ^0.2.6
   uuid@<11.1.1: ^11.1.1
   ws@>=8.0.0 <8.21.0: ^8.21.0
@@ -1434,15 +1432,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3248,8 +3240,8 @@ packages:
   swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
 
-  tar@7.5.20:
-    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
   teeny-request@9.0.0:
@@ -5493,16 +5485,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6897,19 +6880,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimatch@4.2.6:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -6985,7 +6968,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.7.4
-      tar: 7.5.20
+      tar: 7.5.21
       tinyglobby: 0.2.16
       which: 6.0.1
     transitivePeerDependencies:
@@ -7143,7 +7126,7 @@ snapshots:
       proc-log: 6.1.0
       sigstore: 4.1.1
       ssri: 13.0.1
-      tar: 7.5.20
+      tar: 7.5.21
     transitivePeerDependencies:
       - supports-color
 
@@ -7566,7 +7549,7 @@ snapshots:
     dependencies:
       tslib: 2.5.0
 
-  tar@7.5.20:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,19 +3,19 @@ allowBuilds:
 blockExoticSubdeps: true
 engineStrict: true
 minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - "brace-expansion@5.0.8"
 nodeLinker: hoisted
 overrides:
   "@ardatan/relay-compiler@12.0.0>immutable": "^4.3.9"
-  "brace-expansion@<1.1.16": "^1.1.16"
-  "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2"
-  "brace-expansion@>=5.0.0 <5.0.7": "^5.0.7"
+  "brace-expansion@<=5.0.7": "^5.0.8"
   "js-yaml@>=4.0.0 <4.3.0": "^4.3.0"
   "lodash@>=4.0.0 <=4.17.23": "^4.18.0"
   "minimatch@>=4.0.0 <4.2.5": "^4.2.5"
   "protobufjs@>=7.5.0 <=7.6.4": "^7.6.5"
   "shell-quote@<=1.8.4": "^1.10.0"
   "sigstore@<=4.1.0": "^4.1.1"
-  "tar@<=7.5.18": "^7.5.19"
+  "tar@<=7.5.20": "^7.5.21"
   "tmp@<0.2.6": "^0.2.6"
   "uuid@<11.1.1": "^11.1.1"
   "ws@>=8.0.0 <8.21.0": "^8.21.0"


### PR DESCRIPTION
## Summary

The dependency graph now resolves every moderate-or-higher pnpm advisory, including the newly disclosed `brace-expansion` denial-of-service and `tar` recursion issues, without broad dependency upgrades. Older minimatch paths intentionally converge on the registry-recognized patched `brace-expansion` release, with the release-age exception limited to that exact version.

## Validation

- `pnpm install --no-frozen-lockfile`
- `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate --json` — no moderate, high, or critical findings
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec jest --runInBand --no-watchman` — 12 suites and 63 tests passed
- CodeRabbit local review (`--type all --base main`) — no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution rules for improved package version coverage.
  * Updated the permitted `tar` version range.
  * Added an exception allowing a specific `brace-expansion` release to bypass the minimum release age requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->